### PR TITLE
[Bash] Reduce API spam

### DIFF
--- a/bash/bash.py
+++ b/bash/bash.py
@@ -21,5 +21,4 @@ class Bash(BaseCog):
         out = await proc.stdout.read()
         msg = pagify(out.decode('utf-8'))
         await ctx.send(f"```ini\n\n[Bash Input]: {arg}\n```")
-        for page in msg:
-            await ctx.send("```py\n\n{}```".format(page))
+        await ctx.send_interactive(msg, box_lang="py")


### PR DESCRIPTION
This reduces API spam when commands like `man` are used by making all subsequent pages require user input rather than automatically trying to post them all at once.